### PR TITLE
Add function to return receipt deeplink

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,4 +12,5 @@ export const {
     getDataForSession,
     getWebURL,
     getAppURL,
+    getReceiptURL,
 } = createSDK();

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -153,6 +153,16 @@ const _getAppURL = (appId: string, session: Session, callbackURL: string) => {
     return `digime://consent-access?sessionKey=${session.sessionKey}&callbackURL=${encodeURIComponent(callbackURL)}&appId=${appId}&sdkVersion=${sdkVersion}`;
 };
 
+const _getReceiptURL = (contractId: string, appId: string) => {
+    if (!_isValidString(contractId)) {
+        throw new ParameterValidationError("Parameter contractId should be a non empty string");
+    }
+    if (!_isValidString(appId)) {
+        throw new ParameterValidationError("Parameter appId should be a non empty string");
+    }
+    return `digime://receipt?contractid=${contractId}&appid=${appId}`;
+};
+
 const _getFileList = async (sessionKey: string, options: DigiMeSDKConfiguration): Promise<string[]> => {
     const url = `https://${options.host}/${options.version}/permission-access/query/${sessionKey}`;
     const response = await net.get(url, {json: true});
@@ -287,6 +297,7 @@ const createSDK = (sdkOptions?: Partial<DigiMeSDKConfiguration>) => {
         ),
         getWebURL: (session: Session, callbackURL: string) => _getWebURL(session, callbackURL, options),
         getAppURL:  (appId: string, session: Session, callbackURL: string) => _getAppURL(appId, session, callbackURL),
+        getReceiptURL: (contractId: string, appId: string) => _getReceiptURL(contractId, appId),
     };
 };
 


### PR DESCRIPTION
This commit will allow third party developers to trigger a deep link to
any native digi.me app to show consent receipts using a contract ID and
application ID.